### PR TITLE
Mettre en parametre la fonction qui calcule le md5 du repertoire courant

### DIFF
--- a/spip_svn_loader
+++ b/spip_svn_loader
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-PWD_MD5=$(echo `pwd`"spip" |md5sum |awk '{print $1}')
+PWD_MD5=$(echo `pwd`"spip" |sha512sum |cut -d" " -f1)
 #$PWD_MD5=$(md5 -q -s `pwd`"spip")
 
 function ouinon()

--- a/spip_svn_loader
+++ b/spip_svn_loader
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+PWD_MD5=$(echo `pwd`"spip" |md5sum |awk '{print $1}')
+#$PWD_MD5=$(md5 -q -s `pwd`"spip")
+ 
+echo "MD5 = $PWD_MD5"
+
 function ouinon()
 {
     local ouinon
@@ -284,7 +289,7 @@ then
         _chemin=`pwd`
     else
         echo "Ce répertoire est sous SVN. SPIP va être installé dans un sous-répertoire."
-        for d in spip$(md5 -q -s `pwd`"spip") spip; do
+        for d in spip$PWD_MD5 spip; do
             if [ ! -d $d ];then
                 rep=$d
                 _chemin=`pwd`"/$rep"

--- a/spip_svn_loader
+++ b/spip_svn_loader
@@ -168,7 +168,7 @@ then
     else
         _GET_FILE_CMD='wget'
         _CHECK_FILE_CMD='wget -q -S -O - ${SVN_SPIP_REMOTE_REFERENCES} 2>&1'
-        _GET_FILE_OPTIONS='-q -o'
+        _GET_FILE_OPTIONS='-q -O'
     fi
 else
     _GET_FILE_CMD='curl'

--- a/spip_svn_loader
+++ b/spip_svn_loader
@@ -2,8 +2,6 @@
 
 PWD_MD5=$(echo `pwd`"spip" |md5sum |awk '{print $1}')
 #$PWD_MD5=$(md5 -q -s `pwd`"spip")
- 
-echo "MD5 = $PWD_MD5"
 
 function ouinon()
 {

--- a/spip_svn_loader
+++ b/spip_svn_loader
@@ -156,11 +156,24 @@ SVN_SPIP_REFERENCES=$HOME"/.spip/svn_loader_references.txt"
 SVN_SPIP_REMOTE_REFERENCES=http://james.at.rezo.net/svn_spip/svn_spip.txt
 
 #Vérifier que curl est dans le PATH
-curl --version >/dev/null 2>&1
+which curl >/dev/null 2>&1
 if [ $? -ne 0 ]
 then
-    echo "cURL n'est pas installé ou pas dans le PATH"
-    exit 1
+    # Tentative avec wget
+    which wget >/dev/null 2>&1
+    if [ $? -ne 0 ]
+    then
+        echo "ni wget ni cURL ne sont installés ou dans le PATH"
+        exit 1
+    else
+        _GET_FILE_CMD='wget'
+        _CHECK_FILE_CMD='wget -q -S -O - ${SVN_SPIP_REMOTE_REFERENCES} 2>&1'
+        _GET_FILE_OPTIONS='-q -o'
+    fi
+else
+    _GET_FILE_CMD='curl'
+    _CHECK_FILE_CMD='curl -I -s ${SVN_SPIP_REMOTE_REFERENCES}'
+    _GET_FILE_OPTIONS='-s -o'
 fi
 
 #Vérifier la présence du fichier des références
@@ -169,7 +182,7 @@ if [ -f ${SVN_SPIP_REFERENCES} ]
 then
     echo "Le fichier des références est présent."
     #Vérifier la fraicheur du fichier des références
-    _REMOTE=`curl -I -s ${SVN_SPIP_REMOTE_REFERENCES} | grep -e '^Last-Modified: ' | sed 's/^Last-Modified: \(.*\) GMT.*/\1/'`
+    _REMOTE=`${_CHECK_FILE_CMD} | grep -e '^Last-Modified: ' | sed 's/^Last-Modified: \(.*\) GMT.*/\1/'`
     _DARWIN=$(echo $OSTYPE | grep -i darwin)
     if [ -n "$_DARWIN" ]
     then
@@ -197,7 +210,7 @@ then
     then
         mkdir -p ${HOME}/.spip
     fi
-    curl -s -o ${SVN_SPIP_REFERENCES} ${SVN_SPIP_REMOTE_REFERENCES} >/dev/null
+    ${_GET_FILE_CMD} ${_GET_FILE_OPTIONS} ${SVN_SPIP_REFERENCES} ${SVN_SPIP_REMOTE_REFERENCES} >/dev/null
 fi
 
 #Vérifier que PHP est installé et a une version acceptable
@@ -275,7 +288,7 @@ then
         _BRANCHE=$SVN_SPIP_TAGS"/"$brancheREPONSE
     fi
 
-    WC=`find . -type d -maxdepth 1 -name .svn -exec echo {} \;`
+    WC=`find . -maxdepth 1 -type d -name .svn -exec echo {} \;`
     if [ -z "$WC" ]; then
         #Warning si non vide
         VIDE=`ls -1a | grep -v -e "^\.$" | grep -v -e "^\.\.$" | wc -l`


### PR DESCRIPTION
La fonction "md5" n'est pas installée par défaut sous Debian.
J'ai donc utilisé md5sum qui calcule le md5 d'une fonction ou du flux en entrée
Il faudrait peut-être multiplier ce type de paramétrage sur les fonctions de base (curl, en particulier)
